### PR TITLE
Update AutoXMLUpdate

### DIFF
--- a/src/data/AutoXMLUpdate.json
+++ b/src/data/AutoXMLUpdate.json
@@ -1,9 +1,9 @@
 [
   {
     "AutoXMLUpdateID": 1,
-    "FileHash": "77694BCEF178910963CA4AAB8A2F2C4BB516F2D806CA45A2C6507E7A40E48D90",
+    "FileHash": "1219C14B6AB24656EA89F5F54DD3EBD5CF42F9B6E2A673EB346E1CF3FBC8A4E9",
     "FilePackage": "insert/Regions.xml",
-    "LastTimeRowUpdated": "2015-07-15 14:21:34",
+    "LastTimeRowUpdated": "2018-01-04 22:02:53",
     "LoadResult": "SUCCESS"
   },
   {


### PR DESCRIPTION
regions.xml is not the same hash as what we have in the pub db, causes a bunch of errors on first load