### PR TITLE
Set max PvE keep levels to 10

### DIFF
--- a/src/customizations/PveKeeps.sql
+++ b/src/customizations/PveKeeps.sql
@@ -1,3 +1,6 @@
+# Set max keep level to 10
+UPDATE `ServerProperty` SET `Value`="10" WHERE `Key`="max_keep_level";
+
 # Set keeps to PvE
 UPDATE `Keep` SET `Realm`=0, `OriginalRealm`=0 WHERE `Name` LIKE "%Caer%" OR `Name` LIKE "%Faste%" OR `Name` LIKE "%Dun%";
 


### PR DESCRIPTION
Since some of the PvE keeps are being set to level 8, leaving the max keep level server property at 5 is a bad idea.