### PR TITLE
BG Realm Merchant : prepare merchantitem

### DIFF
--- a/schema_mysql/MerchantItem.sql
+++ b/schema_mysql/MerchantItem.sql
@@ -7,6 +7,7 @@ CREATE TABLE `MerchantItem` (
   `SlotPosition` int(11) NOT NULL DEFAULT '0',
   `LastTimeRowUpdated` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   `MerchantItem_ID` varchar(255) NOT NULL,
+  `Price` bigint(20) DEFAULT '0',
   PRIMARY KEY (`MerchantItem_ID`),
   KEY `I_MerchantItem_ItemListID` (`ItemListID`),
   KEY `I_MerchantItem_PageNumber` (`PageNumber`),

--- a/schema_sqlite/MerchantItem.sql
+++ b/schema_sqlite/MerchantItem.sql
@@ -5,7 +5,8 @@ CREATE TABLE `MerchantItem` (`ItemListID` VARCHAR(255) NOT NULL DEFAULT '' COLLA
 `PageNumber` INT(11) NOT NULL DEFAULT 0, 
 `SlotPosition` INT(11) NOT NULL DEFAULT 0, 
 `LastTimeRowUpdated` DATETIME NOT NULL DEFAULT '2000-01-01 00:00:00', 
-`MerchantItem_ID` VARCHAR(255) NOT NULL DEFAULT '' COLLATE NOCASE, 
+`MerchantItem_ID` VARCHAR(255) NOT NULL DEFAULT '' COLLATE NOCASE,
+`Price` BIGINT(20) DEFAULT 0,  
 PRIMARY KEY (`MerchantItem_ID`));
 CREATE INDEX `I_MerchantItem_ItemListID` ON `MerchantItem` (`ItemListID`);
 CREATE INDEX `I_MerchantItem_PageNumber` ON `MerchantItem` (`PageNumber`);


### PR DESCRIPTION
MerchantItem "BGRealmEnhancementTokens" will now include tokens with gold or bounty point version in 2 separate pages

The Price field is now included in the structure of MerchantItem when the DB is created (instead when the server is launched the first time)

Note : The MerchantItem.json is containing many diff due to the Price addition :)
Note2: MerchantItem table where slot -1 is designated for setting currency. The Price field in slot -1 sets the currency ID (1 is Copper, 2 is ItemCurrency (as in Aurulite, Atlantean Glass ...), 3 is BP, 4 is Mithril)