### PR TITLE
Fixed cl spells

### DIFF
--- a/data/LineXSpell.json
+++ b/data/LineXSpell.json
@@ -32069,7 +32069,7 @@
     "LineName": "Champion Disciple 4",
     "LineXSpell_ID": "disciple_column34_row3",
     "PackageID": "NEWCLSYSTEM",
-    "SpellID": 33126
+    "SpellID": 33128
   },
   {
     "LastTimeRowUpdated": "2014-10-26 15:23:16",
@@ -32077,7 +32077,7 @@
     "LineName": "Champion Disciple 4",
     "LineXSpell_ID": "disciple_column34_row4",
     "PackageID": "NEWCLSYSTEM",
-    "SpellID": 33127
+    "SpellID": 33129
   },
   {
     "LastTimeRowUpdated": "2014-10-26 15:23:16",
@@ -32085,7 +32085,7 @@
     "LineName": "Champion Disciple 4",
     "LineXSpell_ID": "disciple_column34_row5",
     "PackageID": "NEWCLSYSTEM",
-    "SpellID": 33128
+    "SpellID": 33130
   },
   {
     "LastTimeRowUpdated": "2014-10-26 15:23:16",
@@ -32093,7 +32093,7 @@
     "LineName": "Champion Disciple 3",
     "LineXSpell_ID": "disciple_column3_row1",
     "PackageID": "NEWCLSYSTEM",
-    "SpellID": 33129
+    "SpellID": 33126
   },
   {
     "LastTimeRowUpdated": "2014-10-26 15:23:16",
@@ -32101,7 +32101,7 @@
     "LineName": "Champion Disciple 3",
     "LineXSpell_ID": "disciple_column3_row2",
     "PackageID": "NEWCLSYSTEM",
-    "SpellID": 33130
+    "SpellID": 33127
   },
   {
     "LastTimeRowUpdated": "2014-10-26 15:23:16",
@@ -32109,7 +32109,7 @@
     "LineName": "Champion Disciple 3",
     "LineXSpell_ID": "disciple_column4_row3",
     "PackageID": "NEWCLSYSTEM",
-    "SpellID": 33126
+    "SpellID": 33128
   },
   {
     "LastTimeRowUpdated": "2014-10-26 15:23:16",
@@ -32117,7 +32117,7 @@
     "LineName": "Champion Disciple 3",
     "LineXSpell_ID": "disciple_column4_row4",
     "PackageID": "NEWCLSYSTEM",
-    "SpellID": 33127
+    "SpellID": 33129
   },
   {
     "LastTimeRowUpdated": "2014-10-26 15:23:16",
@@ -32125,7 +32125,7 @@
     "LineName": "Champion Disciple 3",
     "LineXSpell_ID": "disciple_column4_row5",
     "PackageID": "NEWCLSYSTEM",
-    "SpellID": 33128
+    "SpellID": 33130
   },
   {
     "LastTimeRowUpdated": "2014-10-26 15:23:16",


### PR DESCRIPTION
Corrected a variety of inconsistent and incorrect CL spells.  Things like incorrect durations, damage values, icons, spell types, DoTs  frequencies, disciple buffs being out of order, etc.

This is based on 1.114, right down to the really inconsistent and superfluous DoTs.