### PR TITLE
[CI] Remove caching from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,19 +20,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Build Environment
         uses: dtolnay/rust-toolchain@stable
-      - name: Set up cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.rustup/
-            target/
-          key: cargo-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-test-
       - name: Build public-db-tools
         run: |
           cargo build


### PR DESCRIPTION
It is not working as intended across PRs and therefore pretty useless

The idea was to use the cache for PRs that change the database, but that is not working. It would've still worked when there were changes in an ongoing PR, but I feel like that it is not worth it given the space usage. 